### PR TITLE
New INT size for bot id

### DIFF
--- a/Source/TGPBotConfig.h
+++ b/Source/TGPBotConfig.h
@@ -12,7 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  The bot ID
  */
-@property (nonatomic, readonly) int32_t botId;
+@property (nonatomic, readonly) int64_t botId;
 
 /**
  The bot public key
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param botId the bot ID
  @param publicKey the bot public key
  */
-- (instancetype)initWithBotId:(int32_t)botId publicKey:(NSString *)publicKey;
+- (instancetype)initWithBotId:(int64_t)botId publicKey:(NSString *)publicKey;
 
 @end
 

--- a/Source/TGPBotConfig.m
+++ b/Source/TGPBotConfig.m
@@ -2,7 +2,7 @@
 
 @implementation TGPBotConfig
 
-- (instancetype)initWithBotId:(int32_t)botId publicKey:(NSString *)publicKey {
+- (instancetype)initWithBotId:(int64_t)botId publicKey:(NSString *)publicKey {
     self = [super init];
     if (self != nil) {
         _botId = botId;

--- a/Source/iOS/TGPAppDelegate_iOS.m
+++ b/Source/iOS/TGPAppDelegate_iOS.m
@@ -97,6 +97,7 @@ static NSString *const TGPIncorrectSetupException = @"IncorrectSetupException";
             @"ph.telegra.Telegraph",
             @"org.telegram.TelegramEnterprise",
             @"org.telegram.Telegram-iOS",
+            @"org.telegram.TelegramHD",
         ];
     });
     return [bundleIdentifiers containsObject:bundleIdentifer];


### PR DESCRIPTION
In 2023 year bot id has numbers like 6660853421 and more - signed INT32_t does not conform